### PR TITLE
feat/templates: allow asymetric tests based on `pkg.sh.*` files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@ name = "concourse-matrix"
 version = "0.1.0"
 dependencies = [
  "askama 0.3.4 (git+https://github.com/djc/askama.git)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,6 +104,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +135,23 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,8 +175,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -158,6 +217,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum askama 0.3.4 (git+https://github.com/djc/askama.git)" = "<none>"
 "checksum askama_derive 0.3.4 (git+https://github.com/djc/askama.git)" = "<none>"
 "checksum askama_shared 0.3.4 (git+https://github.com/djc/askama.git)" = "<none>"
@@ -168,13 +228,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ build = "build.rs"
 
 [dependencies]
 askama = { git = "https://github.com/djc/askama.git" }
+regex = "0.2"
+lazy_static = "0.2"
 
 [build-dependencies]
 askama = { git = "https://github.com/djc/askama.git" }

--- a/juice-containers.yml
+++ b/juice-containers.yml
@@ -5,6 +5,13 @@ resources:
     branch: master
     uri: https://github.com/spearow/continuous-integration.git
 
+- name: container-fedora-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-fedora-cuda
+    username: ((quay-username))
+    password: ((quay-password))
+
 - name: container-fedora-default
   type: docker-image
   source:
@@ -19,13 +26,6 @@ resources:
     username: ((quay-username))
     password: ((quay-password))
 
-- name: container-fedora-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-fedora-cuda
-    username: ((quay-username))
-    password: ((quay-password))
-
 - name: container-fedora-opencl
   type: docker-image
   source:
@@ -34,6 +34,13 @@ resources:
     password: ((quay-password))
 
 
+
+- name: container-ubuntu-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-ubuntu-cuda
+    username: ((quay-username))
+    password: ((quay-password))
 
 - name: container-ubuntu-default
   type: docker-image
@@ -49,13 +56,6 @@ resources:
     username: ((quay-username))
     password: ((quay-password))
 
-- name: container-ubuntu-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-ubuntu-cuda
-    username: ((quay-username))
-    password: ((quay-password))
-
 - name: container-ubuntu-opencl
   type: docker-image
   source:
@@ -64,6 +64,13 @@ resources:
     password: ((quay-password))
 
 
+
+- name: container-pureos-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-pureos-cuda
+    username: ((quay-username))
+    password: ((quay-password))
 
 - name: container-pureos-default
   type: docker-image
@@ -76,13 +83,6 @@ resources:
   type: docker-image
   source:
     repository: quay.io/spearow/machine-learning-container-pureos-native
-    username: ((quay-username))
-    password: ((quay-password))
-
-- name: container-pureos-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-pureos-cuda
     username: ((quay-username))
     password: ((quay-password))
 
@@ -106,6 +106,37 @@ resources:
 
 jobs:
 
+
+  - name: build-fedora-cuda
+    serial_groups: [constructors]
+    build_logs_to_retain: 2
+    plan:
+    - aggregate:
+      - get: ci
+        resource: git-continuous-integration
+        trigger: true
+      - get: container
+    - task: gen-container
+      image: container
+      config:
+        platform: linux
+        inputs:
+        - name: ci
+        outputs:
+        - name: recombined
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            cp ci/container/fedora/Dockerfile recombined/Dockerfile
+            cp ci/container/fedora/pkg.sh.cuda recombined/pkg.sh
+            cp ci/container/escalate.sh recombined/escalate.sh
+
+    - put: container-fedora-cuda
+      params:
+        build: recombined
+        tag_as_latest: true
 
   - name: build-fedora-default
     serial_groups: [constructors]
@@ -169,37 +200,6 @@ jobs:
         build: recombined
         tag_as_latest: true
 
-  - name: build-fedora-cuda
-    serial_groups: [constructors]
-    build_logs_to_retain: 2
-    plan:
-    - aggregate:
-      - get: ci
-        resource: git-continuous-integration
-        trigger: true
-      - get: container
-    - task: gen-container
-      image: container
-      config:
-        platform: linux
-        inputs:
-        - name: ci
-        outputs:
-        - name: recombined
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            cp ci/container/fedora/Dockerfile recombined/Dockerfile
-            cp ci/container/fedora/pkg.sh.cuda recombined/pkg.sh
-            cp ci/container/escalate.sh recombined/escalate.sh
-
-    - put: container-fedora-cuda
-      params:
-        build: recombined
-        tag_as_latest: true
-
   - name: build-fedora-opencl
     serial_groups: [constructors]
     build_logs_to_retain: 2
@@ -232,6 +232,37 @@ jobs:
         tag_as_latest: true
 
 
+
+  - name: build-ubuntu-cuda
+    serial_groups: [constructors]
+    build_logs_to_retain: 2
+    plan:
+    - aggregate:
+      - get: ci
+        resource: git-continuous-integration
+        trigger: true
+      - get: container
+    - task: gen-container
+      image: container
+      config:
+        platform: linux
+        inputs:
+        - name: ci
+        outputs:
+        - name: recombined
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            cp ci/container/ubuntu/Dockerfile recombined/Dockerfile
+            cp ci/container/ubuntu/pkg.sh.cuda recombined/pkg.sh
+            cp ci/container/escalate.sh recombined/escalate.sh
+
+    - put: container-ubuntu-cuda
+      params:
+        build: recombined
+        tag_as_latest: true
 
   - name: build-ubuntu-default
     serial_groups: [constructors]
@@ -295,37 +326,6 @@ jobs:
         build: recombined
         tag_as_latest: true
 
-  - name: build-ubuntu-cuda
-    serial_groups: [constructors]
-    build_logs_to_retain: 2
-    plan:
-    - aggregate:
-      - get: ci
-        resource: git-continuous-integration
-        trigger: true
-      - get: container
-    - task: gen-container
-      image: container
-      config:
-        platform: linux
-        inputs:
-        - name: ci
-        outputs:
-        - name: recombined
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            cp ci/container/ubuntu/Dockerfile recombined/Dockerfile
-            cp ci/container/ubuntu/pkg.sh.cuda recombined/pkg.sh
-            cp ci/container/escalate.sh recombined/escalate.sh
-
-    - put: container-ubuntu-cuda
-      params:
-        build: recombined
-        tag_as_latest: true
-
   - name: build-ubuntu-opencl
     serial_groups: [constructors]
     build_logs_to_retain: 2
@@ -358,6 +358,37 @@ jobs:
         tag_as_latest: true
 
 
+
+  - name: build-pureos-cuda
+    serial_groups: [constructors]
+    build_logs_to_retain: 2
+    plan:
+    - aggregate:
+      - get: ci
+        resource: git-continuous-integration
+        trigger: true
+      - get: container
+    - task: gen-container
+      image: container
+      config:
+        platform: linux
+        inputs:
+        - name: ci
+        outputs:
+        - name: recombined
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            cp ci/container/pureos/Dockerfile recombined/Dockerfile
+            cp ci/container/pureos/pkg.sh.cuda recombined/pkg.sh
+            cp ci/container/escalate.sh recombined/escalate.sh
+
+    - put: container-pureos-cuda
+      params:
+        build: recombined
+        tag_as_latest: true
 
   - name: build-pureos-default
     serial_groups: [constructors]
@@ -417,37 +448,6 @@ jobs:
             cp ci/container/escalate.sh recombined/escalate.sh
 
     - put: container-pureos-native
-      params:
-        build: recombined
-        tag_as_latest: true
-
-  - name: build-pureos-cuda
-    serial_groups: [constructors]
-    build_logs_to_retain: 2
-    plan:
-    - aggregate:
-      - get: ci
-        resource: git-continuous-integration
-        trigger: true
-      - get: container
-    - task: gen-container
-      image: container
-      config:
-        platform: linux
-        inputs:
-        - name: ci
-        outputs:
-        - name: recombined
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            cp ci/container/pureos/Dockerfile recombined/Dockerfile
-            cp ci/container/pureos/pkg.sh.cuda recombined/pkg.sh
-            cp ci/container/escalate.sh recombined/escalate.sh
-
-    - put: container-pureos-cuda
       params:
         build: recombined
         tag_as_latest: true

--- a/juice.yml
+++ b/juice.yml
@@ -113,6 +113,13 @@ resources:
     branch: master
     uri: https://github.com/spearow/rust-blas.git
 
+- name: container-fedora-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-fedora-cuda
+    username: ((quay-username))
+    password: ((quay-password))
+
 - name: container-fedora-default
   type: docker-image
   source:
@@ -127,13 +134,6 @@ resources:
     username: ((quay-username))
     password: ((quay-password))
 
-- name: container-fedora-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-fedora-cuda
-    username: ((quay-username))
-    password: ((quay-password))
-
 - name: container-fedora-opencl
   type: docker-image
   source:
@@ -142,6 +142,13 @@ resources:
     password: ((quay-password))
 
 
+
+- name: container-ubuntu-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-ubuntu-cuda
+    username: ((quay-username))
+    password: ((quay-password))
 
 - name: container-ubuntu-default
   type: docker-image
@@ -157,13 +164,6 @@ resources:
     username: ((quay-username))
     password: ((quay-password))
 
-- name: container-ubuntu-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-ubuntu-cuda
-    username: ((quay-username))
-    password: ((quay-password))
-
 - name: container-ubuntu-opencl
   type: docker-image
   source:
@@ -172,6 +172,13 @@ resources:
     password: ((quay-password))
 
 
+
+- name: container-pureos-cuda
+  type: docker-image
+  source:
+    repository: quay.io/spearow/machine-learning-container-pureos-cuda
+    username: ((quay-username))
+    password: ((quay-password))
 
 - name: container-pureos-default
   type: docker-image
@@ -184,13 +191,6 @@ resources:
   type: docker-image
   source:
     repository: quay.io/spearow/machine-learning-container-pureos-native
-    username: ((quay-username))
-    password: ((quay-password))
-
-- name: container-pureos-cuda
-  type: docker-image
-  source:
-    repository: quay.io/spearow/machine-learning-container-pureos-cuda
     username: ((quay-username))
     password: ((quay-password))
 
@@ -454,13 +454,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -468,13 +468,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -482,13 +482,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -496,6 +496,19 @@ jobs:
 
 
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: coaster
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -523,19 +536,6 @@ jobs:
 
           dir: coaster
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: coaster
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -550,6 +550,19 @@ jobs:
           dir: coaster
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: coaster
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -577,19 +590,6 @@ jobs:
 
           dir: coaster
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: coaster
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -604,6 +604,19 @@ jobs:
           dir: coaster
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: coaster
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -628,19 +641,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: coaster
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: coaster
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: coaster
 
@@ -675,13 +675,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -689,13 +689,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -703,13 +703,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -717,6 +717,22 @@ jobs:
 
 
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-blas
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -750,22 +766,6 @@ jobs:
 
           dir: coaster-blas
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-blas
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -783,6 +783,22 @@ jobs:
           dir: coaster-blas
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-blas
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -816,22 +832,6 @@ jobs:
 
           dir: coaster-blas
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-blas
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -849,6 +849,22 @@ jobs:
           dir: coaster-blas
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-blas
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -879,22 +895,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: coaster-blas
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: coaster-blas
 
@@ -937,13 +937,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -951,13 +951,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -965,13 +965,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -979,6 +979,24 @@ jobs:
 
 
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -1016,24 +1034,6 @@ jobs:
 
           dir: coaster-nn
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-nn
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -1053,6 +1053,24 @@ jobs:
           dir: coaster-nn
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -1090,24 +1108,6 @@ jobs:
 
           dir: coaster-nn
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-nn
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -1127,6 +1127,24 @@ jobs:
           dir: coaster-nn
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -1161,24 +1179,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: coaster-nn
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: coaster-nn
 
@@ -1223,13 +1223,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -1237,13 +1237,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -1251,13 +1251,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -1266,6 +1266,23 @@ jobs:
 
         passed: [test-coaster, test-coaster-nn, test-coaster-blas]
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: greenglas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: greenglas
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -1301,23 +1318,6 @@ jobs:
 
           dir: greenglas
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: greenglas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: greenglas
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -1336,6 +1336,23 @@ jobs:
           dir: greenglas
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: greenglas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: greenglas
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -1371,23 +1388,6 @@ jobs:
 
           dir: greenglas
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: greenglas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: greenglas
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -1406,6 +1406,23 @@ jobs:
           dir: greenglas
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: greenglas
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: greenglas
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -1438,23 +1455,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: greenglas
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: greenglas
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: greenglas
 
@@ -1498,13 +1498,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -1512,13 +1512,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -1526,13 +1526,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -1540,6 +1540,25 @@ jobs:
 
 
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -1579,25 +1598,6 @@ jobs:
 
           dir: coaster-nn
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-nn
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -1618,6 +1618,25 @@ jobs:
           dir: coaster-nn
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -1657,25 +1676,6 @@ jobs:
 
           dir: coaster-nn
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: coaster-nn
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -1696,6 +1696,25 @@ jobs:
           dir: coaster-nn
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: coaster-nn
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -1732,25 +1751,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: coaster-nn
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: coaster-nn
 
@@ -1798,13 +1798,13 @@ jobs:
         trigger: true
 
 
+      - get: container-fedora-cuda
+        trigger: true
+
       - get: container-fedora-default
         trigger: true
 
       - get: container-fedora-native
-        trigger: true
-
-      - get: container-fedora-cuda
         trigger: true
 
       - get: container-fedora-opencl
@@ -1812,13 +1812,13 @@ jobs:
 
 
 
+      - get: container-ubuntu-cuda
+        trigger: true
+
       - get: container-ubuntu-default
         trigger: true
 
       - get: container-ubuntu-native
-        trigger: true
-
-      - get: container-ubuntu-cuda
         trigger: true
 
       - get: container-ubuntu-opencl
@@ -1826,13 +1826,13 @@ jobs:
 
 
 
+      - get: container-pureos-cuda
+        trigger: true
+
       - get: container-pureos-default
         trigger: true
 
       - get: container-pureos-native
-        trigger: true
-
-      - get: container-pureos-cuda
         trigger: true
 
       - get: container-pureos-opencl
@@ -1840,6 +1840,26 @@ jobs:
 
 
 
+
+    - task: compile-fedora-cuda
+      image: container-fedora-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        - name: juice-examples
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: juice-examples
 
     - task: compile-fedora-default
       image: container-fedora-default
@@ -1881,26 +1901,6 @@ jobs:
 
           dir: juice-examples
 
-    - task: compile-fedora-cuda
-      image: container-fedora-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        - name: juice-examples
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: juice-examples
-
     - task: compile-fedora-opencl
       image: container-fedora-opencl
       config:
@@ -1922,6 +1922,26 @@ jobs:
           dir: juice-examples
 
 
+
+    - task: compile-ubuntu-cuda
+      image: container-ubuntu-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        - name: juice-examples
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: juice-examples
 
     - task: compile-ubuntu-default
       image: container-ubuntu-default
@@ -1963,26 +1983,6 @@ jobs:
 
           dir: juice-examples
 
-    - task: compile-ubuntu-cuda
-      image: container-ubuntu-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        - name: juice-examples
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
-
-          dir: juice-examples
-
     - task: compile-ubuntu-opencl
       image: container-ubuntu-opencl
       config:
@@ -2004,6 +2004,26 @@ jobs:
           dir: juice-examples
 
 
+
+    - task: compile-pureos-cuda
+      image: container-pureos-cuda
+      config:
+        platform: linux
+        inputs:
+        - name: rust-cudnn
+        - name: rust-blas
+        - name: rust-cublas
+        - name: coaster
+        - name: coaster-blas
+        - name: coaster-nn
+        - name: juice
+        - name: juice-examples
+        run:
+          path: cargo
+
+          args: ["test", "--no-default-features","--features=native,cuda"]
+
+          dir: juice-examples
 
     - task: compile-pureos-default
       image: container-pureos-default
@@ -2042,26 +2062,6 @@ jobs:
           path: cargo
 
           args: ["test", "--no-default-features","--features=native,native"]
-
-          dir: juice-examples
-
-    - task: compile-pureos-cuda
-      image: container-pureos-cuda
-      config:
-        platform: linux
-        inputs:
-        - name: rust-cudnn
-        - name: rust-blas
-        - name: rust-cublas
-        - name: coaster
-        - name: coaster-blas
-        - name: coaster-nn
-        - name: juice
-        - name: juice-examples
-        run:
-          path: cargo
-
-          args: ["test", "--no-default-features","--features=native,cuda"]
 
           dir: juice-examples
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,259 @@
+use std::fs;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use std::env;
+use std::fmt;
 
 #[macro_use]
 extern crate askama;
 
 use askama::Template;
 
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
+
+use regex::Regex;
+
+
+use std::cmp::Ordering;
+
+
+
+
+fn get_pkg_helper_regex(text: &String) -> Option<String> {
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r"^pkg\.sh\.(.*)$").unwrap();
+    }
+    for cap in RE.captures_iter(text) {
+        return Some(cap[1].to_string());
+    }
+    return None;
+}
+
+
+fn get_backends(directory: &Path) -> Vec<String> {
+    fs::read_dir(directory)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| {
+            let pathbuf: PathBuf = entry.path().into();
+            pathbuf
+        })
+        .filter(|entry| entry.is_file())
+        .filter_map(|entry| if let Some(x) = entry.file_name() {
+            Some(String::from(x.to_string_lossy()))
+        } else {
+            None
+        })
+        .filter_map(|entry| get_pkg_helper_regex(&entry))
+        .collect()
+}
+
+
+
+#[derive(Debug)]
+enum TestEnvType {
+    Darwin(String),
+    Linux(String),
+    Windows(String),
+    Unknown,
+}
+
+impl Ord for TestEnvType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match *self {
+            TestEnvType::Linux(ref z) => {
+                match *other {
+                    _ | TestEnvType::Unknown => Ordering::Greater,
+                    TestEnvType::Linux(ref x) => z.cmp(x),
+                    TestEnvType::Darwin(ref x) => Ordering::Less,
+                    TestEnvType::Windows(ref x) => Ordering::Less,
+                }
+            }
+            TestEnvType::Darwin(ref z) => {
+                match *other {
+                    _ | TestEnvType::Unknown => Ordering::Equal,
+                    TestEnvType::Linux(ref x) => Ordering::Greater,
+                    TestEnvType::Darwin(ref x) => z.cmp(x),
+                    TestEnvType::Windows(ref x) => Ordering::Less,
+                }
+            }
+            TestEnvType::Windows(ref z) => {
+                match *other {
+                    _ | TestEnvType::Unknown => Ordering::Less,
+                    TestEnvType::Linux(ref x) => Ordering::Greater,
+                    TestEnvType::Darwin(ref x) => Ordering::Greater,
+                    TestEnvType::Windows(ref x) => z.cmp(x),
+                }
+            }
+            _ | TestEnvType::Unknown => {
+                match *other {
+                    _ | TestEnvType::Unknown => Ordering::Equal,
+                    TestEnvType::Linux(ref x) => Ordering::Less,
+                    TestEnvType::Windows(ref x) => Ordering::Less,
+                    TestEnvType::Darwin(ref x) => Ordering::Less,
+                }
+            }
+        }
+    }
+}
+
+impl PartialOrd for TestEnvType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TestEnvType {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for TestEnvType {}
+
+impl fmt::Display for TestEnvType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Write strictly the first element into the supplied output
+        // stream: `f`. Returns `fmt::Result` which indicates whether the
+        // operation succeeded or failed. Note that `write!` uses syntax which
+        // is very similar to `println!`.
+        let y = String::from("Unknown");
+        let echo = match *self {
+            TestEnvType::Linux(ref x) => x,
+            TestEnvType::Windows(ref x) => x,
+            TestEnvType::Darwin(ref x) => x,
+            _ | TestEnvType::Unknown => &y,
+        };
+        write!(f, "{}", echo)
+    }
+}
+
+#[derive(Debug)]
+struct TestEnv {
+    name: TestEnvType,
+    backends: Vec<String>,
+}
+
+
+
+impl Ord for TestEnv {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for TestEnv {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.name.cmp(&other.name))
+    }
+}
+
+impl PartialEq for TestEnv {
+    fn eq(&self, other: &Self) -> bool {
+        self.name.cmp(&other.name) == Ordering::Equal
+    }
+}
+
+
+impl Eq for TestEnv {}
+
+impl TestEnv {
+    /// TODO currently only Linux envs are supported by this idiotic implementation
+    pub fn new(name: String, backends: Vec<String>) -> Self {
+        Self {
+            name: TestEnvType::Linux(name),
+            backends: backends,
+        }
+    }
+}
+
+impl Default for TestEnv {
+    fn default() -> Self {
+        Self {
+            name: TestEnvType::Unknown,
+            backends: vec![],
+        }
+    }
+}
+
+
 #[derive(Template)]
 #[template(path = "juice.yml")]
 struct JuiceYml<'a> {
-    operatingsystems: &'a Vec<String>,
-    backends: &'a Vec<String>
+    testenvs: &'a Vec<TestEnv>,
 }
 
 #[derive(Template)]
 #[template(path = "juice-containers.yml")]
 struct ContainerYml<'a> {
-    operatingsystems: &'a Vec<String>,
-    backends: &'a Vec<String>
+    testenvs: &'a Vec<TestEnv>,
 }
 
 
-fn main() {
-    // TODO read this from a `matrix.yml` file using yml-rust
-    let operatingsystems = &vec!["fedora".to_string(),"ubuntu".to_string(), "pureos".to_string()];
-    let backends = &vec!["default".to_string(),"native".to_string(),"cuda".to_string(),"opencl".to_string()];
 
-    let juice = JuiceYml {
-         operatingsystems: operatingsystems,
-         backends: backends,
-         };
-    let containers = ContainerYml {
-         operatingsystems: operatingsystems,
-         backends: backends,
-         };
+fn main() {
+    let cwd: PathBuf = env::current_dir().unwrap_or(PathBuf::from("HOME").join("spearow").join(
+        "continuous-integration",
+    ));
+
+    let base: PathBuf = env::var("JUICE_CONTAINERS")
+        .unwrap_or(cwd.join("container").to_string_lossy().to_string())
+        .into();
+
+    println!("Using {} as base container dir", base.display());
+
+
+
+    let mut testenvs: Vec<TestEnv> = fs::read_dir(base)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| {
+            let pathbuf: PathBuf = entry.path().into();
+            pathbuf
+        })
+        .filter_map(|entry| if let Some(x) = entry.file_name() {
+
+            let mut backends = get_backends(&entry);
+            backends.sort();
+            Some(TestEnv::new(String::from(x.to_string_lossy()), backends))
+        } else {
+            None
+        })
+        .collect();
+
+    testenvs.sort();
+
+    for testenv in &testenvs {
+        println!("test envs: {:?}", testenv);
+    }
+
+    let juice = JuiceYml { testenvs: &testenvs };
+    let containers = ContainerYml { testenvs: &testenvs };
 
     let mut f_juice = OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .truncate(true)
-                            .open("juice.yml").unwrap();
-    f_juice.write_all(juice.render().unwrap().as_str().as_bytes()).unwrap();
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("juice.yml")
+        .unwrap();
+    f_juice
+        .write_all(juice.render().unwrap().as_str().as_bytes())
+        .unwrap();
+
     let mut f_containers = OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .truncate(true)
-                            .open("juice-containers.yml").unwrap();
-    f_containers.write_all(containers.render().unwrap().as_str().as_bytes()).unwrap();
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("juice-containers.yml")
+        .unwrap();
+    f_containers
+        .write_all(containers.render().unwrap().as_str().as_bytes())
+        .unwrap();
 }

--- a/templates/container-resourses.yml
+++ b/templates/container-resourses.yml
@@ -1,9 +1,9 @@
-{% for os in operatingsystems %}
-{% for backend in backends %}
-- name: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+- name: container-{{ testenv.name }}-{{ backend }}
   type: docker-image
   source:
-    repository: quay.io/spearow/machine-learning-container-{{ os }}-{{ backend }}
+    repository: quay.io/spearow/machine-learning-container-{{ testenv.name }}-{{ backend }}
     username: ((quay-username))
     password: ((quay-password))
 {% endfor %}

--- a/templates/juice-containers.yml
+++ b/templates/juice-containers.yml
@@ -8,9 +8,9 @@ resources:
 {% include "container-resourses.yml" %}
 
 jobs:
-{% for os in operatingsystems %}
-{% for backend in backends %}
-  - name: build-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+  - name: build-{{ testenv.name }}-{{ backend }}
     serial_groups: [constructors]
     build_logs_to_retain: 2
     plan:
@@ -32,11 +32,11 @@ jobs:
           args:
           - -exc
           - |
-            cp ci/container/{{ os }}/Dockerfile recombined/Dockerfile
-            cp ci/container/{{ os }}/pkg.sh.{{ backend }} recombined/pkg.sh
+            cp ci/container/{{ testenv.name }}/Dockerfile recombined/Dockerfile
+            cp ci/container/{{ testenv.name }}/pkg.sh.{{ backend }} recombined/pkg.sh
             cp ci/container/escalate.sh recombined/escalate.sh
 
-    - put: container-{{ os }}-{{ backend }}
+    - put: container-{{ testenv.name }}-{{ backend }}
       params:
         build: recombined
         tag_as_latest: true

--- a/templates/juice.yml
+++ b/templates/juice.yml
@@ -355,16 +355,16 @@ jobs:
     - aggregate:
       - get: coaster
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:
@@ -394,16 +394,16 @@ jobs:
         trigger: true
       - get: rust-blas
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:
@@ -441,16 +441,16 @@ jobs:
         trigger: true
       - get: coaster-nn
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:
@@ -490,17 +490,17 @@ jobs:
         passed: [test-coaster-nn]
       - get: greenglas
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
         passed: [test-coaster, test-coaster-nn, test-coaster-blas]
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:
@@ -539,16 +539,16 @@ jobs:
         passed: [test-coaster-nn]
       - get: juice
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:
@@ -591,16 +591,16 @@ jobs:
         passed: [test-juice]
       - get: juice-examples
         trigger: true
-{% for os in operatingsystems %}
-{% for backend in backends %}
-      - get: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+      - get: container-{{ testenv.name }}-{{ backend }}
         trigger: true
 {% endfor %}
 {% endfor %}
-{% for os in operatingsystems %}
-{% for backend in backends %}
-    - task: compile-{{ os }}-{{ backend }}
-      image: container-{{ os }}-{{ backend }}
+{% for testenv in testenvs %}
+{% for backend in testenv.backends %}
+    - task: compile-{{ testenv.name }}-{{ backend }}
+      image: container-{{ testenv.name }}-{{ backend }}
       config:
         platform: linux
         inputs:


### PR DESCRIPTION
`cargo run` now compiles and picks up the templates, reads all files
existing in the directory defined by the env variable `JUICE_CONTAINERS` (if unset the equiv of `$(pwd)/containers`),
creates a per container backend list and generates the concourse yml
files based on that.
Note that the sorting has to be kept in order to keep the git diffs
minimal.